### PR TITLE
Add changes to test-helpers to handle test groups

### DIFF
--- a/test-helpers.js
+++ b/test-helpers.js
@@ -1,29 +1,38 @@
-function test(message, actual, expected) {
-  if (actual === expected) {
-    const defaultMessage = `Expected ${expected} and received ${actual}`;
-    console.info("Pass: " + (message || defaultMessage));
-    resetTest();
-  } else {
-    const defaultMessage = `Expected ${expected} but received ${actual} instead`;
-    console.error("Fail: " + (message || defaultMessage));
-    resetTest();
-  }
+function describe(groupName, describeFunction) {
+  console.group("%c " + groupName, "font-size: 13px");
+  describeFunction();
+  console.groupEnd();
 }
 
-function notEqual(actual, expected, message) {
-  if (actual !== expected) {
-    const defaultMessage = `${expected} is different to ${actual}`;
-    console.info("Pass: " + (message || defaultMessage));
-  } else {
-    const defaultMessage = `${expected} is the same as ${actual}`;
-    console.error("Fail: " + (message || defaultMessage));
-  }
+function test(testName, testFunction) {
+  const { result, expected, actual } = testFunction();
+  createFormattedConsoleGroup(testName, result);
+
+  !result &&
+    console.log(
+      `Expected "${expected}" but found %c"${actual}"`,
+      "font-size: 12px; color: red; font-weight: bold"
+    );
+
+  console.groupEnd();
+  resetTestEnvironment();
+  return { result };
 }
 
-function describe(name, testFunction) {
-  console.group(name);
-  testFunction();
-  console.groupEnd(name);
+function createFormattedConsoleGroup(testName, result) {
+  console[result ? "groupCollapsed" : "group"](
+    (result ? "✅" : "❌") + ` ${testName}`
+  );
+}
+
+function equal(actual, expected) {
+  if (actual === expected) return { result: true };
+
+  return {
+    result: false,
+    expected,
+    actual,
+  };
 }
 
 function $(object) {

--- a/test-helpers.js
+++ b/test-helpers.js
@@ -16,7 +16,6 @@ function test(testName, testFunction) {
 
   console.groupEnd();
   resetTestEnvironment();
-  return { result };
 }
 
 function createFormattedConsoleGroup(testName, result) {

--- a/tests.js
+++ b/tests.js
@@ -2,25 +2,37 @@ const testListEl = document.querySelector(".list");
 const testInput = document.querySelector("input");
 const testSaveBtn = document.querySelector(".save-btn");
 
-describe("When changes input value", () => {
-  testInput.value = "Shopping";
-  test("standard strings are used", testInput.value, "Shopping");
+describe("When user changes input value", () => {
+  test("standard strings", () => {
+    testInput.value = "Shopping";
+    return equal(testInput.value, "Shopping");
+  });
+
+  test("random symbols", () => {
+    testInput.value = "%*!'l;";
+    return equal(testInput.value, "%*!'l;");
+  });
+
+  test("random numbers", () => {
+    testInput.value = "12345675";
+    return equal(testInput.value, "12345675");
+  });
 });
 
 describe("When user clicks save", () => {
-  emulateInputAndClick("Run");
-  test("list length is updated", testListEl.children.length, 1);
+  test("list length is updated on task creation", () => {
+    emulateInputAndClick("Run");
+    return equal(testListEl.children.length, 1);
+  });
 
-  emulateInputAndClick("Call 074 9124-1237");
-  const newTask = document.querySelector("li");
-  test(
-    "correct content is added to the new task",
-    newTask.textContent,
-    "Call 074 9124-1237"
-  );
+  test("correct content is added to the new task", () => {
+    emulateInputAndClick("Call John at: 074 9124-1237");
+    const newTask = document.querySelector("li");
+    return equal(newTask.textContent, "Call John at: 074 9124-1237");
+  });
 });
 
-function resetTest() {
+function resetTestEnvironment() {
   testListEl.innerHTML = "";
   testInput.value = "";
 }

--- a/tests.js
+++ b/tests.js
@@ -15,7 +15,7 @@ describe("When user changes input value", () => {
 
   test("random numbers", () => {
     testInput.value = "12345675";
-    return equal(testInput.value, "12345675");
+    return equal(testInput.value, "12345635");
   });
 });
 


### PR DESCRIPTION
The following changes have been added in this PR:

- Add functionality to allow groups within groups - this should allow the developers to better organize related tests
- Add logic to interpret whether `equal` fails or passes within a `test`
- Add icons to `test` output when it fails or passes
- Add dynamic group creation: if `equal` returns true `test` will be created as `console.groupCollapsed()`. This will hopefully reduce the amount of unnecessary info being displayed to the developer.
- Automatically expand failed tests to display the formatted error message

![image](https://user-images.githubusercontent.com/53922624/177412606-c1d46b79-a489-4d6f-971e-193995ae1fa9.png)



The test-helper functions have been updated to resemble the Jest workflow:
`test()` should always return a boolean

```
describe("name for related group of tests", () =>{
   test("name of what is being tested",  () => { 
     // write test content
     
     return equal(actual, expected)   // Assert whether the `actual` output matches our `expected` output 
   }
}
```