### PR TITLE
Toggle completed

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,16 +11,17 @@ function createTodo() {
   const listEl = document.querySelector("ul");
   const newTask = document.createElement("li");
 
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+
+  const newTaskName = document.createElement("p");
+  newTaskName.textContent = inputValue;
+
   const deleteBtn = document.createElement("button");
-  deleteBtn.textContent = "Delete"
-  deleteBtn.setAttribute("class", "delete-btn")
-  deleteBtn.addEventListener("click", () => [
-    newTask.remove()
-  ])
+  deleteBtn.textContent = "Delete";
+  deleteBtn.setAttribute("class", "delete-btn");
+  deleteBtn.addEventListener("click", () => newTask.remove());
 
-  newTask.textContent = inputValue;
+  newTask.append(checkbox, newTaskName, deleteBtn);
   listEl.append(newTask);
-  newTask.append(deleteBtn)
-
 }
-

--- a/index.js
+++ b/index.js
@@ -10,23 +10,38 @@ function createTodo() {
   const inputValue = document.querySelector("input").value;
   const listEl = document.querySelector("ul");
   const newTask = document.createElement("li");
+
   newTask.dataset.completed = false;
 
+  // Create children
+  const checkbox = createCheckbox(newTask);
+  const deleteBtn = createDeleteBtn(newTask);
+  const newTaskName = document.createElement("p");
+
+  newTaskName.textContent = inputValue;
+
+  newTask.append(checkbox, newTaskName, deleteBtn);
+  listEl.append(newTask);
+}
+
+function createCheckbox(newTask) {
   const checkbox = document.createElement("input");
+
   checkbox.type = "checkbox";
   checkbox.addEventListener("click", () => {
     newTask.classList.toggle("completed");
     newTask.dataset.completed = !JSON.parse(newTask.dataset.completed);
   });
 
-  const newTaskName = document.createElement("p");
-  newTaskName.textContent = inputValue;
+  return checkbox;
+}
 
+function createDeleteBtn(newTask) {
   const deleteBtn = document.createElement("button");
+
   deleteBtn.textContent = "Delete";
   deleteBtn.setAttribute("class", "delete-btn");
   deleteBtn.addEventListener("click", () => [newTask.remove()]);
 
-  newTask.append(checkbox, newTaskName, deleteBtn);
-  listEl.append(newTask);
+  return deleteBtn;
 }

--- a/index.js
+++ b/index.js
@@ -10,9 +10,14 @@ function createTodo() {
   const inputValue = document.querySelector("input").value;
   const listEl = document.querySelector("ul");
   const newTask = document.createElement("li");
+  newTask.dataset.completed = false;
 
   const checkbox = document.createElement("input");
   checkbox.type = "checkbox";
+  checkbox.addEventListener("click", () => {
+    newTask.classList.toggle("completed");
+    newTask.dataset.completed = !JSON.parse(newTask.dataset.completed);
+  });
 
   const newTaskName = document.createElement("p");
   newTaskName.textContent = inputValue;
@@ -20,7 +25,7 @@ function createTodo() {
   const deleteBtn = document.createElement("button");
   deleteBtn.textContent = "Delete";
   deleteBtn.setAttribute("class", "delete-btn");
-  deleteBtn.addEventListener("click", () => newTask.remove());
+  deleteBtn.addEventListener("click", () => [newTask.remove()]);
 
   newTask.append(checkbox, newTaskName, deleteBtn);
   listEl.append(newTask);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,4 @@
+li {
+  display: flex;
+  align-items: center;
+}

--- a/style.css
+++ b/style.css
@@ -2,3 +2,8 @@ li {
   display: flex;
   align-items: center;
 }
+
+.completed {
+  text-decoration: line-through;
+  opacity: 0.5;
+}

--- a/tests.js
+++ b/tests.js
@@ -45,13 +45,32 @@ describe("When user clicks save", () => {
   test("renders task checkbox", () => {
     emulateInputAndClick("newTask");
     const newTask = document.querySelector("li");
-    const checkbox = newTask.querySelector("input[type='checkbox']");
+    const checkbox = newTask.querySelector("input");
 
     return equal(Boolean(checkbox), true);
   });
 });
 
-describe("When user clicks task checkbox", () => {});
+describe("When user clicks task checkbox", () => {
+  test("it toggles the task's 'completed' class", () => {
+    emulateInputAndClick("mock test item");
+    const newTask = document.querySelector("li");
+    const checkbox = newTask.querySelector("input");
+    checkbox.click();
+
+    return equal(newTask.classList.contains("completed"), true);
+  });
+
+  test("it toggles data-completed value", () => {
+    emulateInputAndClick("mock test item");
+    const newTask = document.querySelector("li");
+    const checkbox = newTask.querySelector("input");
+    checkbox.click();
+
+    const isTaskCompleted = newTask.dataset.completed === "true";
+    return equal(isTaskCompleted, true);
+  });
+});
 
 describe("User delete a task from the list", () => {
   test("user insert exsting task name and click delete button to delete the task", () => {

--- a/tests.js
+++ b/tests.js
@@ -2,7 +2,6 @@ const testListEl = document.querySelector(".list");
 const testInput = document.querySelector("input");
 const testSaveBtn = document.querySelector(".save-btn");
 
-
 describe("When user changes input value", () => {
   test("standard strings", () => {
     testInput.value = "Shopping";
@@ -29,37 +28,60 @@ describe("When user clicks save", () => {
   test("correct content is added to the new task", () => {
     emulateInputAndClick("Call John at: 074 9124-1237");
     const newTask = document.querySelector("li");
-    return equal(newTask.textContent.slice(0, -6), "Call John at: 074 9124-1237");
+    return equal(
+      newTask.textContent.slice(0, -6),
+      "Call John at: 074 9124-1237"
+    );
+  });
+
+  test("renders delete button", () => {
+    emulateInputAndClick("newTask");
+    const newTask = document.querySelector("li");
+    const deleteButton = newTask.querySelector("button");
+
+    return equal(Boolean(deleteButton), true);
+  });
+
+  test("renders task checkbox", () => {
+    emulateInputAndClick("newTask");
+    const newTask = document.querySelector("li");
+    const checkbox = newTask.querySelector("input[type='checkbox']");
+
+    return equal(Boolean(checkbox), true);
   });
 });
 
+describe("When user clicks task checkbox", () => {});
 
 describe("User delete a task from the list", () => {
   test("user insert exsting task name and click delete button to delete the task", () => {
-    emulateInputAndClick("toDelete")
-    emulateInputAndClick("toDelete2")
+    emulateInputAndClick("toDelete");
+    emulateInputAndClick("toDelete2");
     const testDeleteBtn = document.querySelectorAll(".delete-btn");
-    testDeleteBtn[0].click()
-    return equal(testListEl.innerHTML, `<li>toDelete2<button class="delete-btn">Delete</button></li>`)
-  })
+    testDeleteBtn[0].click();
+    return equal(
+      testListEl.innerHTML,
+      `<li>toDelete2<button class="delete-btn">Delete</button></li>`
+    );
+  });
   test("user insert exsting task name and click delete button to delete multiple tasks", () => {
-    emulateInputAndClick("toDelete")
-    emulateInputAndClick("toDelete1")
-    emulateInputAndClick("toDelete2")
-    emulateInputAndClick("toDelete3")
-    emulateInputAndClick("toDelete4")
-    emulateInputAndClick("toDelete5")
+    emulateInputAndClick("toDelete");
+    emulateInputAndClick("toDelete1");
+    emulateInputAndClick("toDelete2");
+    emulateInputAndClick("toDelete3");
+    emulateInputAndClick("toDelete4");
+    emulateInputAndClick("toDelete5");
     const testDeleteBtn = document.querySelectorAll(".delete-btn");
-    testDeleteBtn[0].click()
-    testDeleteBtn[2].click()
-    testDeleteBtn[4].click()
-    testDeleteBtn[5].click()
-    return equal(testListEl.innerHTML, `<li>toDelete1<button class="delete-btn">Delete</button></li><li>toDelete3<button class="delete-btn">Delete</button></li>`)
-  })
-})
-
-
-
+    testDeleteBtn[0].click();
+    testDeleteBtn[2].click();
+    testDeleteBtn[4].click();
+    testDeleteBtn[5].click();
+    return equal(
+      testListEl.innerHTML,
+      `<li>toDelete1<button class="delete-btn">Delete</button></li><li>toDelete3<button class="delete-btn">Delete</button></li>`
+    );
+  });
+});
 
 function resetTestEnvironment() {
   testListEl.innerHTML = "";
@@ -70,4 +92,3 @@ function emulateInputAndClick(text) {
   testInput.value = text;
   saveBtn.click();
 }
-


### PR DESCRIPTION
The following changes have been made:
- Add checkbox to allow users to toggle tasks as completed
- Functionality to toggle `completed` class, for future styling
- Add 'completed' to the task `dataset`, which will allow us to filter for 'completed' tasks in the future
- Refactored createTodo(), by creating `createCheckbox()` and `createDeleteBtn()`

Seeing that we have created a new element and class, our tests using `testListEl.innerHTML` are now failing.
We should reconsider using innerHTML for these tests, otherwise we'll have to continually update them whenever changes are made to the list content. #8